### PR TITLE
Set max APCu version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.6
 
 before_script:
-  - yes | pecl install -f apcu
+  - yes | pecl install -f apcu-4.0.6
   - echo "apc.enabled=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - wget http://getcomposer.org/composer.phar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ And you can launch coke
 ./vendor/bin/coke
 ```
 
+*NB: due to an update in APCu API, ApcuBundle 1.1.0 is the last version who work with APCu < 4.0.7*
+
 ## Testing
 
 This bundle is tested with [atoum](https://github.com/atoum/atoum).

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description" : "Provide APCu support",
     "require": {
         "php": ">=5.5",
-        "ext-apcu": "~4.0"
+        "ext-apcu": ">=4.0,<4.0.7"
     },
     "require-dev": {
         "atoum/atoum"           : "~1.0",


### PR DESCRIPTION
As APCu introduce an BC in it API, this PR lock the max APCu extension version to avoid error
cf. https://github.com/krakjoe/apcu/issues/50
