### PR TITLE
Fix guzzle adapters

### DIFF
--- a/src/M6Web/Bundle/ApcuBundle/CacheAdapters/M6WebGuzzleHttp.php
+++ b/src/M6Web/Bundle/ApcuBundle/CacheAdapters/M6WebGuzzleHttp.php
@@ -22,7 +22,11 @@ class M6WebGuzzleHttp extends BaseApcu implements CacheInterface
      */
     public function get($key)
     {
-        return $this->fetch($key);
+        if (($value = $this->fetch($key)) === false) {
+            return null;
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
Apcu fetch return false if not found, change for return null instead.
(https://github.com/M6Web/GuzzleHttpBundle/blob/master/src/Handler/CacheTrait.php#L133)
